### PR TITLE
TASK-4957 reworked storage of last location game mode and visibility …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>0.7.5</revision>
+		<revision>0.8.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -35,7 +35,8 @@
 	<distributionManagement>
 		<site>
 			<id>${project.artifactId}-site</id>
-			<url>file:///tmp/dummy-site</url> <!-- Needs to be defined here to avoid that "PowerCamera" is appended to the staging directory. -->
+			<url>file:///tmp/dummy-site
+			</url> <!-- Needs to be defined here to avoid that "PowerCamera" is appended to the staging directory. -->
 		</site>
 	</distributionManagement>
 
@@ -43,7 +44,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.16.3-R0.1-20201025.071724-27</version>
+			<version>1.20.4-R0.1-20240423.152506-123</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/nl/svenar/powercamera/PowerCamera.java
+++ b/src/main/java/nl/svenar/powercamera/PowerCamera.java
@@ -1,12 +1,8 @@
 package nl.svenar.powercamera;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import nl.svenar.powercamera.commands.MainCommand;
+import nl.svenar.powercamera.config.ActiveCameraStorage;
 import nl.svenar.powercamera.config.CameraStorage;
 import nl.svenar.powercamera.config.PluginConfig;
 import nl.svenar.powercamera.events.ChatTabExecutor;
@@ -19,6 +15,11 @@ import org.bukkit.ChatColor;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @SuppressFBWarnings({"DLS_DEAD_LOCAL_STORE", "MS_MUTABLE_COLLECTION_PKGPROTECT", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"})
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.AvoidDuplicateLiterals", "PMD.AvoidReassigningLoopVariables", "PMD.CognitiveComplexity", "PMD.CommentRequired", "PMD.CyclomaticComplexity", "PMD.LocalVariableCouldBeFinal", "PMD.LooseCoupling", "PMD.UnnecessaryImport", "PMD.UseDiamondOperator"})
 public class PowerCamera extends JavaPlugin {
@@ -27,12 +28,12 @@ public class PowerCamera extends JavaPlugin {
 
     public static final List<String> DONATION_URLS = Arrays.asList("https://ko-fi.com/svenar", "https://patreon.com/svenar");
 
-    private PlayerCameraDataTracker playerCameraDataTracker;
-
     // public Map<UUID, String> playerSelectedCamera = new HashMap<>(); // Selected camera name
     // public Map<UUID, CameraMode> playerCameraMode = new HashMap<>(); // When the player is viewing the camera (/pc start & /pc preview)
     // public Map<UUID, CameraHandler> playerCameraHandler = new HashMap<>(); // When the player is viewing the camera (/pc start & /pc preview)
     public Instant powercameraStartTime = Instant.now();
+
+    private PlayerCameraDataTracker playerCameraDataTracker;
 
     private PluginDescriptionFile pdf;
 
@@ -41,6 +42,8 @@ public class PowerCamera extends JavaPlugin {
     private PluginConfig configPlugin;
 
     private CameraStorage configCameras;
+
+    private ActiveCameraStorage configActiveCameras;
 
     private MainCommand mainCommand;
 
@@ -93,6 +96,7 @@ public class PowerCamera extends JavaPlugin {
     private void setupConfig() {
         configPlugin = new PluginConfig(this, "config.yml");
         configCameras = new CameraStorage(this);
+        configActiveCameras = new ActiveCameraStorage(this);
 
         configPlugin.getConfig().set("version", null);
         configCameras.getConfig().set("version", null);
@@ -148,6 +152,10 @@ public class PowerCamera extends JavaPlugin {
 
     public CameraStorage getConfigCameras() {
         return configCameras;
+    }
+
+    public ActiveCameraStorage getConfigActiveCameras() {
+        return configActiveCameras;
     }
 
     public MainCommand getMainCommand() {

--- a/src/main/java/nl/svenar/powercamera/Util.java
+++ b/src/main/java/nl/svenar/powercamera/Util.java
@@ -1,22 +1,17 @@
 package nl.svenar.powercamera;
 
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.entity.Player;
-import org.bukkit.potion.PotionEffectType;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
 @SuppressWarnings({"PMD.CommentRequired", "PMD.FieldDeclarationsShouldBeAtStartOfClass", "PMD.LocalVariableCouldBeFinal", "PMD.MethodArgumentCouldBeFinal", "PMD.ShortClassName", "PMD.ShortVariable"})
 public final class Util {
-
-    private Util() {
-    }
 
     private static final Pattern REGEX_INT = Pattern.compile("^\\d+[^a-zA-Z]?$");
 
@@ -25,6 +20,9 @@ public final class Util {
     private static final Pattern REGEX_MINUTES = Pattern.compile("\\d+[mM]");
 
     private static final Pattern REGEX_HOURS = Pattern.compile("\\d+[hH]");
+
+    private Util() {
+    }
 
     public static String serializeLocation(Location loc) {
         return loc.getWorld().getUID() + ";" + loc.getX() + ";" + loc.getY() + ";" + loc.getZ() + ";" + loc.getYaw() + ";" + loc.getPitch();
@@ -76,13 +74,5 @@ public final class Util {
         }
 
         return seconds;
-    }
-
-    public static boolean isPlayerInvisible(Player player) {
-        try {
-            return player.isInvisible();
-        } catch (NoSuchMethodError e) {
-            return player.hasPotionEffect(PotionEffectType.INVISIBILITY);
-        }
     }
 }

--- a/src/main/java/nl/svenar/powercamera/config/ActiveCameraStorage.java
+++ b/src/main/java/nl/svenar/powercamera/config/ActiveCameraStorage.java
@@ -29,11 +29,6 @@ public class ActiveCameraStorage {
     private static final PersistentDataGameMode PERSISTENT_DATA_GAME_MODE = new PersistentDataGameMode();
 
     /**
-     * The persistent data boolean type.
-     */
-    private static final PersistentDataBoolean PERSISTENT_DATA_BOOLEAN = new PersistentDataBoolean();
-
-    /**
      * The active camera key.
      */
     private final NamespacedKey activeCamera;
@@ -80,8 +75,8 @@ public class ActiveCameraStorage {
         if (!persistentDataContainer.has(lastGameMode, PERSISTENT_DATA_GAME_MODE)) {
             persistentDataContainer.set(lastGameMode, PERSISTENT_DATA_GAME_MODE, player.getGameMode());
         }
-        if (!persistentDataContainer.has(lastVisibility, PERSISTENT_DATA_BOOLEAN)) {
-            persistentDataContainer.set(lastVisibility, PERSISTENT_DATA_BOOLEAN, player.isInvisible());
+        if (!persistentDataContainer.has(lastVisibility, PersistentDataType.BOOLEAN)) {
+            persistentDataContainer.set(lastVisibility, PersistentDataType.BOOLEAN, player.isInvisible());
         }
     }
 
@@ -108,7 +103,7 @@ public class ActiveCameraStorage {
         }
         persistentDataContainer.remove(lastGameMode);
         if (visibility) {
-            final Boolean visibilityValue = persistentDataContainer.get(lastVisibility, PERSISTENT_DATA_BOOLEAN);
+            final Boolean visibilityValue = persistentDataContainer.get(lastVisibility, PersistentDataType.BOOLEAN);
             if (visibilityValue != null) {
                 player.setInvisible(visibilityValue);
             }
@@ -189,32 +184,6 @@ public class ActiveCameraStorage {
         @Override
         public @NotNull GameMode fromPrimitive(@NotNull final String primitive, @NotNull final PersistentDataAdapterContext context) {
             return GameMode.valueOf(primitive);
-        }
-    }
-
-    /**
-     * {@link PersistentDataType} for {@link Boolean}.
-     */
-    private static final class PersistentDataBoolean implements PersistentDataType<Byte, Boolean> {
-
-        @Override
-        public @NotNull Class<Byte> getPrimitiveType() {
-            return Byte.class;
-        }
-
-        @Override
-        public @NotNull Class<Boolean> getComplexType() {
-            return Boolean.class;
-        }
-
-        @Override
-        public @NotNull Byte toPrimitive(@NotNull final Boolean complex, @NotNull final PersistentDataAdapterContext context) {
-            return complex ? (byte) 1 : 0;
-        }
-
-        @Override
-        public @NotNull Boolean fromPrimitive(@NotNull final Byte primitive, @NotNull final PersistentDataAdapterContext context) {
-            return primitive == 1;
         }
     }
 }

--- a/src/main/java/nl/svenar/powercamera/config/ActiveCameraStorage.java
+++ b/src/main/java/nl/svenar/powercamera/config/ActiveCameraStorage.java
@@ -1,0 +1,220 @@
+package nl.svenar.powercamera.config;
+
+import nl.svenar.powercamera.PowerCamera;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.util.NumberConversions;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Storage for active cameras.
+ */
+public class ActiveCameraStorage {
+    /**
+     * The persistent data location type.
+     */
+    private static final PersistentDataLocation PERSISTENT_DATA_LOCATION = new PersistentDataLocation();
+
+    /**
+     * The persistent data game mode type.
+     */
+    private static final PersistentDataGameMode PERSISTENT_DATA_GAME_MODE = new PersistentDataGameMode();
+
+    /**
+     * The persistent data boolean type.
+     */
+    private static final PersistentDataBoolean PERSISTENT_DATA_BOOLEAN = new PersistentDataBoolean();
+
+    /**
+     * The active camera key.
+     */
+    private final NamespacedKey activeCamera;
+
+    /**
+     * The last location key.
+     */
+    private final NamespacedKey lastLocation;
+
+    /**
+     * The last game mode key.
+     */
+    private final NamespacedKey lastGameMode;
+
+    /**
+     * The last visibility key.
+     */
+    private final NamespacedKey lastVisibility;
+
+    /**
+     * Instantiates a new Active camera storage.
+     *
+     * @param plugin The plugin.
+     */
+    public ActiveCameraStorage(final PowerCamera plugin) {
+        activeCamera = new NamespacedKey(plugin, "activeCamera");
+        lastLocation = new NamespacedKey(plugin, "lastLocation");
+        lastGameMode = new NamespacedKey(plugin, "lastGameMode");
+        lastVisibility = new NamespacedKey(plugin, "lastVisibility");
+    }
+
+    /**
+     * Set the camera for a player as active.
+     *
+     * @param cameraName The camera name.
+     * @param player     The player.
+     */
+    public void setCameraActive(final String cameraName, final Player player) {
+        final PersistentDataContainer persistentDataContainer = player.getPersistentDataContainer();
+        persistentDataContainer.set(activeCamera, PersistentDataType.STRING, cameraName);
+        if (!persistentDataContainer.has(lastLocation, PERSISTENT_DATA_LOCATION)) {
+            persistentDataContainer.set(lastLocation, PERSISTENT_DATA_LOCATION, player.getLocation());
+        }
+        if (!persistentDataContainer.has(lastGameMode, PERSISTENT_DATA_GAME_MODE)) {
+            persistentDataContainer.set(lastGameMode, PERSISTENT_DATA_GAME_MODE, player.getGameMode());
+        }
+        if (!persistentDataContainer.has(lastVisibility, PERSISTENT_DATA_BOOLEAN)) {
+            persistentDataContainer.set(lastVisibility, PERSISTENT_DATA_BOOLEAN, player.isInvisible());
+        }
+    }
+
+    /**
+     * Set the camera for a player as inactive.
+     *
+     * @param player The player.
+     */
+    public void setCameraInactive(final Player player, final boolean location, final boolean gameMode, final boolean visibility) {
+        final PersistentDataContainer persistentDataContainer = player.getPersistentDataContainer();
+        persistentDataContainer.remove(activeCamera);
+        if (location) {
+            final Location locationValue = persistentDataContainer.get(lastLocation, PERSISTENT_DATA_LOCATION);
+            if (locationValue != null) {
+                player.teleport(locationValue);
+            }
+        }
+        persistentDataContainer.remove(lastLocation);
+        if (gameMode) {
+            final GameMode gameModeValue = persistentDataContainer.get(lastGameMode, PERSISTENT_DATA_GAME_MODE);
+            if (gameModeValue != null) {
+                player.setGameMode(gameModeValue);
+            }
+        }
+        persistentDataContainer.remove(lastGameMode);
+        if (visibility) {
+            final Boolean visibilityValue = persistentDataContainer.get(lastVisibility, PERSISTENT_DATA_BOOLEAN);
+            if (visibilityValue != null) {
+                player.setInvisible(visibilityValue);
+            }
+        }
+        persistentDataContainer.remove(lastVisibility);
+    }
+
+    /**
+     * Get the active camera for a player.
+     *
+     * @param player The player.
+     * @return The active camera or null if no camera is active.
+     */
+    @Nullable
+    public String getActiveCamera(final Player player) {
+        return player.getPersistentDataContainer().get(activeCamera, PersistentDataType.STRING);
+    }
+
+    /**
+     * {@link PersistentDataType} for {@link Location}.
+     */
+    private static final class PersistentDataLocation implements PersistentDataType<String, Location> {
+
+        @Override
+        public @NotNull Class<String> getPrimitiveType() {
+            return String.class;
+        }
+
+        @Override
+        public @NotNull Class<Location> getComplexType() {
+            return Location.class;
+        }
+
+        @Override
+        public @NotNull String toPrimitive(@NotNull final Location complex, @NotNull final PersistentDataAdapterContext context) {
+            final World world = complex.getWorld();
+            final String worldName = world == null ? "" : world.getName();
+            return String.format("%s;%s;%s;%s;%s;%s", worldName, complex.getX(), complex.getY(), complex.getZ(), complex.getYaw(), complex.getPitch());
+        }
+
+        @Override
+        public @NotNull Location fromPrimitive(@NotNull final String primitive, @NotNull final PersistentDataAdapterContext context) {
+            final String[] parts = primitive.split(";");
+
+            World world = null;
+            final String worldName = parts[0];
+            if (worldName != null && !worldName.isEmpty()) {
+                world = Bukkit.getWorld(worldName);
+                if (world == null) {
+                    throw new IllegalArgumentException("unknown world");
+                }
+            }
+            return new Location(world, NumberConversions.toDouble(parts[1]), NumberConversions.toDouble(parts[2]),
+                    NumberConversions.toDouble(parts[3]), NumberConversions.toFloat(parts[4]), NumberConversions.toFloat(parts[5]));
+        }
+    }
+
+    /**
+     * {@link PersistentDataType} for {@link GameMode}.
+     */
+    private static final class PersistentDataGameMode implements PersistentDataType<String, GameMode> {
+
+        @Override
+        public @NotNull Class<String> getPrimitiveType() {
+            return String.class;
+        }
+
+        @Override
+        public @NotNull Class<GameMode> getComplexType() {
+            return GameMode.class;
+        }
+
+        @Override
+        public @NotNull String toPrimitive(@NotNull final GameMode complex, @NotNull final PersistentDataAdapterContext context) {
+            return complex.name();
+        }
+
+        @Override
+        public @NotNull GameMode fromPrimitive(@NotNull final String primitive, @NotNull final PersistentDataAdapterContext context) {
+            return GameMode.valueOf(primitive);
+        }
+    }
+
+    /**
+     * {@link PersistentDataType} for {@link Boolean}.
+     */
+    private static final class PersistentDataBoolean implements PersistentDataType<Byte, Boolean> {
+
+        @Override
+        public @NotNull Class<Byte> getPrimitiveType() {
+            return Byte.class;
+        }
+
+        @Override
+        public @NotNull Class<Boolean> getComplexType() {
+            return Boolean.class;
+        }
+
+        @Override
+        public @NotNull Byte toPrimitive(@NotNull final Boolean complex, @NotNull final PersistentDataAdapterContext context) {
+            return complex ? (byte) 1 : 0;
+        }
+
+        @Override
+        public @NotNull Boolean fromPrimitive(@NotNull final Byte primitive, @NotNull final PersistentDataAdapterContext context) {
+            return primitive == 1;
+        }
+    }
+}

--- a/src/main/java/nl/svenar/powercamera/config/CameraStorage.java
+++ b/src/main/java/nl/svenar/powercamera/config/CameraStorage.java
@@ -1,6 +1,11 @@
 package nl.svenar.powercamera.config;
 
-import java.io.File;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import nl.svenar.powercamera.PowerCamera;
+import nl.svenar.powercamera.Util;
+import org.bukkit.Location;
+import org.bukkit.configuration.InvalidConfigurationException;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,55 +13,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import nl.svenar.powercamera.PowerCamera;
-import nl.svenar.powercamera.Util;
-import org.bukkit.Location;
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
-
 @SuppressFBWarnings({"CT_CONSTRUCTOR_THROW", "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
 @SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.AvoidPrintStackTrace", "PMD.AvoidReassigningParameters", "PMD.CommentRequired", "PMD.LinguisticNaming", "PMD.LocalVariableCouldBeFinal", "PMD.MethodArgumentCouldBeFinal", "PMD.TooManyMethods", "PMD.UseCollectionIsEmpty", "PMD.UseDiamondOperator"})
-public class CameraStorage {
-
-    private File configFile;
-
-    private FileConfiguration config;
-
-    private final PowerCamera plugin;
-
+public class CameraStorage extends PluginConfig {
     public CameraStorage(PowerCamera plugin) {
-        this.plugin = plugin;
-
-        createConfigFile();
-    }
-
-    private void createConfigFile() {
-        configFile = new File(plugin.getDataFolder(), "camera.yml");
-        if (!configFile.exists()) {
-            configFile.getParentFile().mkdirs();
-            plugin.saveResource("camera.yml", false);
-        }
-
-        config = new YamlConfiguration();
-        try {
-            config.load(configFile);
-        } catch (IOException | InvalidConfigurationException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public FileConfiguration getConfig() {
-        return this.config;
-    }
-
-    public void saveConfig() {
-        try {
-            this.config.save(this.configFile);
-        } catch (IOException e) {
-            plugin.getLogger().severe("Error saving " + configFile.getName());
-        }
+        super(plugin, "camera.yml");
     }
 
     public void reloadConfig() {

--- a/src/main/java/nl/svenar/powercamera/config/PluginConfig.java
+++ b/src/main/java/nl/svenar/powercamera/config/PluginConfig.java
@@ -1,54 +1,68 @@
 package nl.svenar.powercamera.config;
 
-import java.io.File;
-import java.io.IOException;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import nl.svenar.powercamera.PowerCamera;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+
 @SuppressFBWarnings({"CT_CONSTRUCTOR_THROW", "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"})
 @SuppressWarnings({"PMD.AvoidPrintStackTrace", "PMD.CommentRequired", "PMD.MethodArgumentCouldBeFinal"})
 public class PluginConfig {
 
-    private File configFile;
+    protected final PowerCamera plugin;
 
-    private FileConfiguration config;
+    protected final File configFile;
 
-    private final PowerCamera plugin;
+    protected final FileConfiguration config;
 
     public PluginConfig(PowerCamera plugin, String fileName) {
         this.plugin = plugin;
 
-        createConfigFile(fileName);
+        configFile = createConfigFile(fileName);
+        config = createConfig(configFile);
     }
 
-    private void createConfigFile(String fileName) {
-        configFile = new File(plugin.getDataFolder(), fileName);
-        if (!configFile.exists()) {
-            configFile.getParentFile().mkdirs();
-            plugin.saveResource(fileName, false);
+    private File createConfigFile(final String fileName) {
+        final File file = new File(plugin.getDataFolder(), fileName);
+        if (!file.exists()) {
+            file.getParentFile().mkdirs();
+            if (plugin.getResource(fileName) == null) {
+                try {
+                    file.createNewFile();
+                } catch (IOException e) {
+                    plugin.getLogger().log(Level.SEVERE, "Error creating " + file.getName(), e);
+                }
+            } else {
+                plugin.saveResource(fileName, false);
+            }
         }
+        return file;
+    }
 
-        config = new YamlConfiguration();
+    private FileConfiguration createConfig(File file) {
+        final FileConfiguration config = new YamlConfiguration();
         try {
-            config.load(configFile);
+            config.load(file);
         } catch (IOException | InvalidConfigurationException e) {
-            e.printStackTrace();
+            plugin.getLogger().log(Level.SEVERE, "Error loading " + file.getName(), e);
         }
-    }
-
-    public FileConfiguration getConfig() {
-        return this.config;
+        return config;
     }
 
     public void saveConfig() {
         try {
             this.config.save(this.configFile);
         } catch (IOException e) {
-            plugin.getLogger().severe("Error saving " + configFile.getName());
+            plugin.getLogger().log(Level.SEVERE, "Error saving " + configFile.getName(), e);
         }
+    }
+
+    public FileConfiguration getConfig() {
+        return this.config;
     }
 }

--- a/src/main/java/nl/svenar/powercamera/tracker/PlayerCameraDataTracker.java
+++ b/src/main/java/nl/svenar/powercamera/tracker/PlayerCameraDataTracker.java
@@ -1,10 +1,11 @@
 package nl.svenar.powercamera.tracker;
 
+import nl.svenar.powercamera.data.PlayerCameraData;
+import org.bukkit.entity.Player;
+
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import nl.svenar.powercamera.data.PlayerCameraData;
-import org.bukkit.entity.Player;
 
 @SuppressWarnings({"PMD.AtLeastOneConstructor", "PMD.CommentRequired", "PMD.MethodArgumentCouldBeFinal"})
 public class PlayerCameraDataTracker {
@@ -24,7 +25,6 @@ public class PlayerCameraDataTracker {
     }
 
     public void handlePlayerQuit(Player player) {
-        cameraDataMap.remove(player.getUniqueId());
+        cameraDataMap.remove(player.getUniqueId()).getCameraHandler().cancel();
     }
-
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,44 +1,44 @@
 name: '${project.name}'
 version: '${project.version}'
 main: nl.svenar.powercamera.PowerCamera
-api-version: 1.13
+api-version: 1.20
 description: "Power Camera: Create awesome cinematic videos"
-authors: [svenar_nl]
+authors: [ svenar_nl ]
 website: 'http://dev.bukkit.org/bukkit-plugins/powercamera/'
 commands:
-    powercamera:
-        description: Main command
-        aliases: [powercam, pcam, pc, cam]
+  powercamera:
+    description: Main command
+    aliases: [ powercam, pcam, pc, cam ]
 permissions:
-    powercamera.cmd.help:
-        default: op
-    powercamera.cmd.reload:
-        default: op
-    powercamera.cmd.create:
-        default: op
-    powercamera.cmd.remove:
-        default: op
-    powercamera.cmd.addpoint:
-        default: op
-    powercamera.cmd.delpoint:
-        default: op
-    powercamera.cmd.select:
-        default: op
-    powercamera.cmd.preview:
-        default: op
-    powercamera.cmd.info:
-        default: op
-    powercamera.cmd.setduration:
-        default: op
-    powercamera.cmd.start:
-        default: op
-    powercamera.cmd.startother:
-        default: op
-    powercamera.cmd.stop:
-        default: op
-    powercamera.cmd.stats:
-        default: op
-    powercamera.hidestartmessages:
-        default: not op
-    powercamera.bypass.joincamera:
-        default: false
+  powercamera.cmd.help:
+    default: op
+  powercamera.cmd.reload:
+    default: op
+  powercamera.cmd.create:
+    default: op
+  powercamera.cmd.remove:
+    default: op
+  powercamera.cmd.addpoint:
+    default: op
+  powercamera.cmd.delpoint:
+    default: op
+  powercamera.cmd.select:
+    default: op
+  powercamera.cmd.preview:
+    default: op
+  powercamera.cmd.info:
+    default: op
+  powercamera.cmd.setduration:
+    default: op
+  powercamera.cmd.start:
+    default: op
+  powercamera.cmd.startother:
+    default: op
+  powercamera.cmd.stop:
+    default: op
+  powercamera.cmd.stats:
+    default: op
+  powercamera.hidestartmessages:
+    default: not op
+  powercamera.bypass.joincamera:
+    default: false


### PR DESCRIPTION
…of the player to restore it after a camera and also to replay a camera after a logout

<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
