### PR TITLE
TASK-4911 fixed possible NPE when a player quits the game

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>0.8.0</revision>
+		<revision>0.8.1</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 

--- a/src/main/java/nl/svenar/powercamera/tracker/PlayerCameraDataTracker.java
+++ b/src/main/java/nl/svenar/powercamera/tracker/PlayerCameraDataTracker.java
@@ -1,5 +1,6 @@
 package nl.svenar.powercamera.tracker;
 
+import nl.svenar.powercamera.CameraHandler;
 import nl.svenar.powercamera.data.PlayerCameraData;
 import org.bukkit.entity.Player;
 
@@ -25,6 +26,9 @@ public class PlayerCameraDataTracker {
     }
 
     public void handlePlayerQuit(Player player) {
-        cameraDataMap.remove(player.getUniqueId()).getCameraHandler().cancel();
+        final CameraHandler cameraHandler = cameraDataMap.remove(player.getUniqueId()).getCameraHandler();
+        if (cameraHandler != null) {
+            cameraHandler.cancel();
+        }
     }
 }


### PR DESCRIPTION
<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
