### PR TITLE
TASK-4950 PowerCamera is now a Paper only plugin to fix that you can …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
 	<properties>
 		<!-- project version -->
-		<revision>0.8.1</revision>
+		<revision>0.9.0</revision>
 		<changelist>-SNAPSHOT</changelist>
 	</properties>
 
@@ -27,8 +27,8 @@
 			<url>https://nexus.reloadkube.managedservices.resilient-teched.com/repository/reload/</url>
 		</repository>
 		<repository>
-			<id>spigotmc-repo</id>
-			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+			<id>papermc</id>
+			<url>https://repo.papermc.io/repository/maven-public/</url>
 		</repository>
 	</repositories>
 
@@ -42,9 +42,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.spigotmc</groupId>
-			<artifactId>spigot-api</artifactId>
-			<version>1.20.4-R0.1-20240423.152506-123</version>
+			<groupId>io.papermc.paper</groupId>
+			<artifactId>paper-api</artifactId>
+			<version>1.20.4-R0.1-20241030.192207-176</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/nl/svenar/powercamera/PowerCamera.java
+++ b/src/main/java/nl/svenar/powercamera/PowerCamera.java
@@ -47,8 +47,23 @@ public class PowerCamera extends JavaPlugin {
 
     private MainCommand mainCommand;
 
+    private static boolean hasClass(final String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     @Override
     public void onEnable() {
+        if (!(hasClass("com.destroystokyo.paper.PaperConfig") || hasClass("io.papermc.paper.configuration.Configuration"))) {
+            getLogger().severe("This plugin requires Paper to run. Please install Paper and restart your server.");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        }
+
         pdf = this.getDescription();
 
         pluginChatPrefix = pluginChatPrefix.replace("%pluginName%", pdf.getName());

--- a/src/main/java/nl/svenar/powercamera/events/PlayerMoveHandler.java
+++ b/src/main/java/nl/svenar/powercamera/events/PlayerMoveHandler.java
@@ -1,5 +1,6 @@
 package nl.svenar.powercamera.events;
 
+import com.destroystokyo.paper.event.player.PlayerStartSpectatingEntityEvent;
 import nl.svenar.powercamera.PowerCamera;
 import nl.svenar.powercamera.data.CameraMode;
 import nl.svenar.powercamera.data.PlayerCameraData;
@@ -21,9 +22,17 @@ public class PlayerMoveHandler implements Listener {
     public void onPlayerMove(PlayerMoveEvent event) {
         PlayerCameraData playerCameraData = plugin.getPlayerData().get(event.getPlayer());
 
-        if (playerCameraData.getCameraMode() == CameraMode.PREVIEW) {
+        if (playerCameraData.getCameraMode() != CameraMode.NONE) {
             event.setCancelled(true);
         }
+    }
 
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onPlayerSpectate(PlayerStartSpectatingEntityEvent event) {
+        PlayerCameraData playerCameraData = plugin.getPlayerData().get(event.getPlayer());
+
+        if (playerCameraData.getCameraMode() != CameraMode.NONE) {
+            event.setCancelled(true);
+        }
     }
 }


### PR DESCRIPTION
…spectate entities while a camera is active

<!-- BEGIN Global settings -->
<!-- TODO: Please describe your changes here. -->

---
<!-- Git and GitHub -->
- [x] The main commit(s) reference the Fibery ticket via a `TASK-NNNN` prefix in the commit message subject
- [x] Include a human-readable description of what the pull request is trying to accomplish
- [x] The CI build passes
---
<!-- Testing; only one of the following needs to be checked: -->
- [ ] New automated tests have been added
- [ ] The changes are already covered by automated tests and have been adapted
- [ ] These manual test cases cover this change:
- [ ] Steps for the reviewer(s) on how they can manually QA the changes:
- [ ] This is a minor internal change; basic CI/CD coverage is enough
- [ ] This is an incomplete feature hidden behind feature flag:
- [ ] This is proof-of-concept / experimental code not for production / marked `@Deprecated`
- [ ] No (significant) changes to production code
---
<!-- Documentation -->
- [ ] Classes and public methods have documentation (that doesn't just repeat the technical subject in English)
- [ ] Logging is implemented to monitor feature usage and troubleshoot problems in production
- [ ] These ReWiki pages are affected by this change and will be adapted:
<!-- END Global settings -->
---
<!-- Support matrix -->
- [ ] The change is unrelated to Minecraft
- [ ] Works in Java edition
- [ ] Works in Bedrock edition
